### PR TITLE
feature/fix-root-highlight

### DIFF
--- a/harmony/static/js/src/util/analyze.js
+++ b/harmony/static/js/src/util/analyze.js
@@ -330,6 +330,9 @@ AtoGsemitoneIndices: [9, 11, 0, 2, 4, 5, 7],
 			return !isNaN(root) && typeof root !== 'undefined' && root !== null && root !== '_';
 		};
 
+		// notes should be in sorted order
+		notes.sort(function(a,b) { return a - b; });
+
 		if(this.Piano.key === "h") {
 			entry = this.getIntervalsAboveBass(notes);
 			if (this.hChords[entry]) {


### PR DESCRIPTION
This pull request addresses an issue with the "root highlight" mode. The issue is that when there is more than one instance of a root in a chord, none of the instances are highlighted. The expected behavior is that _at least one_ of the roots should be highlighted. 

There are three possible ways to address the issue:
- Highlight the _highest_ root in the chord.
- Highlight the _lowest_ root in the chord.
- Highlight _all_ roots in the chord.

This PR implements the last option, highlight all roots, because (a) there is no consensus about which way is the best and (b) this approach is most likely to elicit feedback from learners about whether it is helpful or not.
