### PR TITLE
Fix issue with minor and no key analysis

### DIFF
--- a/harmony/static/js/src/util/analyze.js
+++ b/harmony/static/js/src/util/analyze.js
@@ -348,9 +348,9 @@ AtoGsemitoneIndices: [9, 11, 0, 2, 4, 5, 7],
 			}
 		} else {
 			entry = this.getOrderedPitchClasses(notes);
-			chords = this.iChords;
-			if(this.Piano.key.indexOf('i') === -1) {
-				chords = this.jChords; // major
+			chords = this.jChords;
+			if(this.Piano.key.indexOf('i') !== -1) {
+				chords = this.iChords; // minor
 			}
 			if(chords[entry]) {
 				root = chords[entry]["root"];
@@ -535,34 +535,51 @@ AtoGsemitoneIndices: [9, 11, 0, 2, 4, 5, 7],
 	//
 	// Note: pulled out from the ijNameDegree function
 	getSolfege: function(notes) {
-		var i;
-		if(notes.length == 1) {
-			i = this.distance([this.Piano.keynotePC,notes[0] % 12]);
-			return this.jDegrees[i]["solfege"];
+		var distance, scale_degrees, scale_degree, solfege = "";
+		var is_minor = (this.Piano.key.indexOf("i") !== -1);
+
+		if(notes.length == 1 && this.Piano.key !== 'h') {
+			distance = this.distance([this.Piano.keynotePC,notes[0] % 12]);
+			scale_degrees = (is_minor ? this.iDegrees : this.jDegrees);
+			scale_degree = scale_degrees[distance];
+			if(!scale_degree) {
+				return "";
+			}
+			solfege = scale_degree["solfege"];
 		}
-		return "";
+		return solfege;
 	},
 
 	// Returns the scale degree for a note.
 	//
 	// Note: pulled out from the ijNameDegree function
 	getScaleDegree: function(notes) {
-		var i, numeral = '';
-		if(notes.length == 1) {
-			i = this.distance([this.Piano.keynotePC,notes[0] % 12]);
-			if (this.jDegrees[i] !== undefined) {
-				numeral = this.jDegrees[i]["numeral"];
-				if (this.Piano.key.indexOf("i") != -1) {	// minor key variations; index changed to i from m -Rowland
-					if (numeral == "b3") numeral = '3';
-					else if (numeral == "3") numeral = '#3';
-					else if (numeral == "b6") numeral = '6'
-					else if (numeral == "6") numeral = '#6'
-					else if (numeral == "b7") numeral = '7';
-					else if (numeral == "7") numeral = '#7';
-				}
-				return numeral;
+		var distance, scale_degrees, scale_degree, numeral = '';
+		var is_minor = (this.Piano.key.indexOf("i") !== -1);
+		var minor_key_override = {
+			"b3": "3",
+			"3": "#3",
+			"b6": "6",
+			"b7": "7",
+			"7": "#7"
+		};
+
+		if(notes.length == 1 && this.Piano.key !== 'h') {
+			distance = this.distance([this.Piano.keynotePC, notes[0] % 12]);
+			scale_degrees = (is_minor ? this.iDegrees : this.jDegrees);
+			scale_degree = scale_degrees[distance];
+			if(!scale_degree) {
+				return '';
 			}
+
+			numeral = scale_degree["numeral"];
+
+			// override for minor key variations (from Rowland)
+			if(is_minor && minor_key_override.hasOwnProperty(numeral)) {
+				numeral = minor_key_override[numeral];
+			} 
 		}
+
 		return numeral;
 	},
 	getNameOfNote: function(notes) {

--- a/harmony/static/js/src/view/transcript/stave_notater.js
+++ b/harmony/static/js/src/view/transcript/stave_notater.js
@@ -257,17 +257,19 @@ define([
 		drawScaleDegree: function(x, y) {
 			var ctx = this.getContext();
 			var notes = this.chord.getNoteNumbers();
-			var numeral = this.getAnalyzer().getScaleDegree(notes);
 			var width = 0, caret_offset = 0, caret_x = x;
+			var numeral = this.getAnalyzer().getScaleDegree(notes);
 
-			numeral = this.convertSymbols(numeral);
-			width = ctx.measureText(numeral).width;
-			//x = x + 8 + Math.floor(width/2);
-			caret_offset = ctx.measureText(numeral.slice(0,-1)).width;
-			caret_x = x - 1 + (numeral.length > 1 ? caret_offset : 0);
+			if(numeral !== '') {
+				numeral = this.convertSymbols(numeral);
+				width = ctx.measureText(numeral).width;
+				//x = x + 8 + Math.floor(width/2);
+				caret_offset = ctx.measureText(numeral.slice(0,-1)).width;
+				caret_x = x - 1 + (numeral.length > 1 ? caret_offset : 0);
 
-			ctx.fillText(numeral, x, y);
-			ctx.fillText("^", caret_x, y - 10);
+				ctx.fillText(numeral, x, y);
+				ctx.fillText("^", caret_x, y - 10);
+			}
 		},
 		/**
 		 * Draws the roman numeral analysis.


### PR DESCRIPTION
This PR addresses two issues:
1. Make sure that the minor scale degrees table is being used for analysis (iDegrees is for minor keys and jDegrees is for major keys).
2. Make sure that _scale degree_ and _solfege_ analysis is **not** done when the key signature is set to "no key" because it doesn't make sense in that context.

There is also some minor refactoring in this PR, but all of it related to the first two items.
