### PR TITLE
feature/fix-interval-entry

### DIFF
--- a/harmony/static/js/spec/util_analyze_spec.js
+++ b/harmony/static/js/spec/util_analyze_spec.js
@@ -1,0 +1,51 @@
+define([
+	'lodash',
+	'app/model/key_signature',
+	'app/util/analyze'
+], function(_, KeySignature, Analyze) {
+
+	describe("getIntervalsAboveBass", function() {
+		var key_signature = new KeySignature();
+		var analyze = new Analyze(key_signature);
+
+		it("gets interval entry regardless of note order", function() {
+			var expected_interval_entry = "47";
+			var note_tests = [
+				[65, 69, 72],
+				[53, 69, 72],
+				[53, 60, 69]
+			];
+
+			_.each(note_tests, function(notes) {
+				var entry = analyze.getIntervalsAboveBass(notes);
+				expect(entry).toBe(expected_interval_entry);
+			});
+		});
+	});
+
+	describe("stripRepeatedPitchClasses", function() {
+		var key_signature = new KeySignature();
+		var analyze = new Analyze(key_signature);
+
+		it("returns all the notes because they are unique pitch classes", function() {
+			var notes = [60,65,71];
+			var uniquePitches = analyze.stripRepeatedPitchClasses(notes);
+			expect(uniquePitches).toEqual(notes);
+		});
+
+		it("returns only the first note because they are all the same pitch class", function() {
+			var notes = [36,48,60,72,84];
+			var expected = [36];
+			var uniquePitches = analyze.stripRepeatedPitchClasses(notes);
+			expect(uniquePitches).toEqual(expected);
+		});
+	
+		it("returns only the unique pitch classes", function() {
+			var notes = [48,60,65,71,72,73,77,84,85,86];
+			var expected = [48,65,71,73,86];
+			var uniquePitches = analyze.stripRepeatedPitchClasses(notes);
+			expect(uniquePitches).toEqual(expected);
+		});
+	});
+
+});


### PR DESCRIPTION
This PR fixes an issue with "no key" analysis of chords and in particular the intervals above the bass. The issue is that several chords map to the same interval entry that appears in the analysis table, but there seems to be a bug where depending on the order of the notes, the mapping is incorrect (i.e. a chord maps to "74" instead of "47" as expected).

The issue is in the `getIntervalsAboveBass(notes)` function, which obtains the correct intervals of the notes above the bass note, but doesn't ensure that the ordering is correct. The solution is to sort the intervals after they are obtained and then convert them to the entry string (basically just mash the intervals above the bass together so intervals [4,7] map to entry "47").

Concrete example: 
- Notes [65,69,72] should map to entry "47" because those are notes [F/5,A/5,C/6] with pitch classes 0,4,7. The bass is F, pitch 0 and the resulting entry string is "47."
- Notes [53,69,72] should map to entry "47" because those are notes [F/4,A/5,C/6] with pitch classes 0,4,7. The bass is F, pitch 0 and the resulting entry string is "47."
- Notes [53,60,69] should map to entry "47" because those are notes [F/4,C/5,A/5] with pitch classes 0,7,4. The bass is F, pitch 0, so the result _should_ be entry string "47", but instead the entry string is "74."

So this PR fixes that issue and also refactors several supporting/related methods and includes a unit test for the method that was fixed.

@jazahn Can you review this?
