### PR TITLE
feature/replace-helmholtz-with-scientific

### DIFF
--- a/harmony/static/js/src/components/music/stave_notater.js
+++ b/harmony/static/js/src/components/music/stave_notater.js
@@ -249,6 +249,23 @@ define([
 			}
 		},
 		/**
+		 * Draws the name of a note in scientific pitch notation.
+		 *
+		 * @param {number} x
+		 * @param {number} y
+		 * @return undefined
+		 */
+		drawScientificPitch: function(x, y) {
+			var ctx = this.getContext();
+			var notes = this.chord.getNoteNumbers();
+			var note_name = this.getAnalyzer().getNoteName(notes[0],notes);
+			var scientific_pitch = this.getAnalyzer().toScientificPitchNotation(note_name);
+
+			if(scientific_pitch !== '') {
+				ctx.fillText(scientific_pitch, x, y);
+			}
+		},
+		/**
 		 * Draws solfege.
 		 *
 		 * @param {number} x
@@ -482,8 +499,8 @@ define([
 				// second row of mutually exclusive options
 				if(mode.note_names && !mode.helmholtz) {
 					this.drawNoteName(x, second_row);
-				} else if(mode.helmholtz && !mode.note_names) {
-					this.drawHelmholtz(x, second_row);
+				} else if(mode.scientific_pitch && !mode.note_names) {
+					this.drawScientificPitch(x, second_row);
 				}
 			}
 		},

--- a/harmony/static/js/src/config/general.js
+++ b/harmony/static/js/src/config/general.js
@@ -312,10 +312,10 @@ define({
 		enabled: true,
 		// Enables or disables specific analysis modes
 		mode: {
-			note_names: false, // mutually exclusive with helmholtz
-			helmholtz: false, // see note_names
+			note_names: false, // mutually exclusive with scientific_pitch
+			scientific_pitch: false, 
 			scale_degrees: true, // mutually exclusive with solfege
-			solfege: false, // see scale_degrees
+			solfege: false, 
 			roman_numerals: true,
 			intervals: true
 		}

--- a/harmony/static/js/src/utils/analyze.js
+++ b/harmony/static/js/src/utils/analyze.js
@@ -310,10 +310,11 @@ AtoGsemitoneIndices: [9, 11, 0, 2, 4, 5, 7],
 	toScientificPitchNotation: function (note) {
 		var noteParts = note.split('/');
 		var scientific_pitch = "";
+		var noteName, octave;
 		if(noteParts.length == 2) {
-			var noteName = noteParts[0];
-			var octave = parseInt(noteParts[1], 10);
-			var scientific_pitch = noteName[0].toUpperCase() + noteName.slice(1) + octave;
+			noteName = noteParts[0];
+			octave = parseInt(noteParts[1], 10);
+			scientific_pitch = noteName[0].toUpperCase() + noteName.slice(1) + octave;
 		}
 		return scientific_pitch;
 	},

--- a/harmony/static/js/src/utils/analyze.js
+++ b/harmony/static/js/src/utils/analyze.js
@@ -286,9 +286,9 @@ AtoGsemitoneIndices: [9, 11, 0, 2, 4, 5, 7],
 // The following eleven scripts do important thinking about pitches, accidentals, roots.
 
 	toHelmholtzNotation: function (note) {
-		noteName = note.split('/')[0]
+		var noteName = note.split('/')[0]
+		var octave = parseInt(note.split('/')[1], 10);
 		noteName = noteName[0].toUpperCase() + noteName.slice(1)
-		var octave = parseInt(note.split('/')[1]);
 		switch (octave) {
 			case 0: 
 				noteName = noteName+' ,,';
@@ -306,6 +306,16 @@ AtoGsemitoneIndices: [9, 11, 0, 2, 4, 5, 7],
 				break;
 		}
 		return noteName;
+	},
+	toScientificPitchNotation: function (note) {
+		var noteParts = note.split('/');
+		var scientific_pitch = "";
+		if(noteParts.length == 2) {
+			var noteName = noteParts[0];
+			var octave = parseInt(noteParts[1], 10);
+			var scientific_pitch = noteName[0].toUpperCase() + noteName.slice(1) + octave;
+		}
+		return scientific_pitch;
 	},
 	stripRepeatedPitchClasses: function (notes) {
 		var dict = {}, stripped = [];

--- a/harmony/static/js/src/widgets/analyze.js
+++ b/harmony/static/js/src/widgets/analyze.js
@@ -17,8 +17,8 @@ define([
 				'label': 'Note names',
 				'value': 'analyze.note_names',
 			},{
-				'label': 'Helmholtz',
-				'value': 'analyze.helmholtz'
+				'label': 'Scientific Pitch',
+				'value': 'analyze.scientific_pitch'
 			}],
 			[{
 				'label': 'Scale degrees',


### PR DESCRIPTION
Replaced the [helmholtz](http://en.wikipedia.org/wiki/Helmholtz_pitch_notation) analysis option with [scientific pitch notation](http://en.wikipedia.org/wiki/Scientific_pitch_notation). This was requested by Rowland. I left the helmholtz method in the code since we may want to use it later or make it available somehow.

@jazahn Can you review?

---
[HLAB-83](https://jira.huit.harvard.edu/browse/HLAB-83)